### PR TITLE
Unlink zipped database after it is closed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,8 @@ def _unpack_db():
             db_content = f.read()
             with open(TARGET_DB, "wb") as out:
                 out.write(db_content)
-            # delete the xz file
-            os.unlink("jamdict_data/jamdict.db.xz")
+        # delete the xz file
+        os.unlink(ZIPPED_DB)
 
 
 class InstallUnpackDatabase(install):


### PR DESCRIPTION
`jamdict-data` fails to install via pip on Windows platforms due to attempting to remove a file that's still open.  Fixes #1.

